### PR TITLE
feat :[최재민] mung Wiki도매인을 관리 하기 위한 엔티티 설계 시스템[mung-back7]

### DIFF
--- a/src/main/kotlin/com/example/mungmung/member/controller/NaverRequest.kt
+++ b/src/main/kotlin/com/example/mungmung/member/controller/NaverRequest.kt
@@ -1,0 +1,12 @@
+package com.example.mungmung.member.controller
+
+import lombok.Data
+import lombok.Getter
+
+@Getter
+@Data
+class NaverRequest {
+
+    private val code: String? = null
+    private val state: String? = null
+}

--- a/src/main/kotlin/com/example/mungmung/mungWiki/controller/mungWikiController.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/controller/mungWikiController.kt
@@ -1,0 +1,24 @@
+package com.example.mungmung.mungWiki.controller
+
+import com.example.mungmung.mungWiki.request.RegisterRequest
+import com.example.mungmung.mungWiki.service.MungWikiService
+import lombok.extern.slf4j.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.bind.annotation.*
+
+@Slf4j
+@RestController
+@RequestMapping("/mungWiki")
+@CrossOrigin(origins = ["*"], allowedHeaders = ["*"])
+class MungWikiController {
+
+    @Autowired
+    private lateinit var mungWikiService: MungWikiService
+
+    @PostMapping("/register")
+    open fun wikiRegister(@RequestBody registerRequest: RegisterRequest) : String{
+
+
+        return mungWikiService.registerWiki(registerRequest)
+    }
+}

--- a/src/main/kotlin/com/example/mungmung/mungWiki/entity/DogStatus.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/entity/DogStatus.kt
@@ -1,0 +1,59 @@
+package com.example.mungmung.mungWiki.entity
+
+import jakarta.persistence.*
+import lombok.NoArgsConstructor
+import lombok.Setter
+import org.jetbrains.annotations.NotNull
+
+@Entity
+@NoArgsConstructor
+@Setter
+class DogStatus() {
+
+    constructor(
+        intelligenceLevel: Long?,
+        sheddingLevel: Long?,
+        sociabilityLevel: Long?,
+        activityLevel: Long?,
+        indoorAdaptLevel: Long?) : this(){
+        this.intelligenceLevel = intelligenceLevel
+        this.sheddingLevel = sheddingLevel
+        this.sociabilityLevel = sociabilityLevel
+        this.activityLevel = activityLevel
+        this.indoorAdaptLevel = indoorAdaptLevel
+    }
+
+    @Id
+    @Column(name = "wikiStatus_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private var id : Long? = null
+
+    @Column(nullable = false)
+    @NotNull
+    private var intelligenceLevel : Long? = null
+
+    @Column(nullable = false)
+    @NotNull
+    private var sheddingLevel : Long? = null
+
+    @Column(nullable = false)
+    @NotNull
+    private var sociabilityLevel : Long? = null
+
+    @Column(nullable = false)
+    @NotNull
+    private var activityLevel : Long? = null
+
+    @Column(nullable = false)
+    @NotNull
+    private var indoorAdaptLevel : Long? = null
+
+    @PrePersist
+    private fun validate() {
+        require(intelligenceLevel != null &&  0<= intelligenceLevel!! || intelligenceLevel!! <= 5) { "intelligenceLevel must be between 0 and 5" }
+        require(sheddingLevel != null &&  0<= sheddingLevel!! || sheddingLevel!! <= 5) { "sheddingLevel must be between 0 and 5" }
+        require(sociabilityLevel != null &&  0<= sociabilityLevel!! || sociabilityLevel!! <= 5) { "sociabilityLevel must be between 0 and 5" }
+        require(activityLevel != null && 0<= activityLevel!! || activityLevel!! <= 5) { "activityLevel must be between 0 and 5" }
+        require(indoorAdaptLevel != null && 0<= indoorAdaptLevel!! ||indoorAdaptLevel!! <= 5) { "indoorAdaptLevel must be between 0 and 5" }
+    }
+}

--- a/src/main/kotlin/com/example/mungmung/mungWiki/entity/DogType.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/entity/DogType.kt
@@ -1,0 +1,4 @@
+package com.example.mungmung.mungWiki.entity
+
+enum class DogType {
+}

--- a/src/main/kotlin/com/example/mungmung/mungWiki/entity/DogType.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/entity/DogType.kt
@@ -1,4 +1,39 @@
 package com.example.mungmung.mungWiki.entity
 
-enum class DogType {
+enum class DogType(val type: String) {
+
+    POODLE("푸들"),
+    SHIH_TZU("시츄"),
+    BICHON_FRIZE("비숑프리제"),
+    POMERANIAN("포메라니안"),
+    MALTESE("말티즈"),
+    YORKSHIRE_TERRIER("요크셔테리어"),
+    CHIHUAHUA("치와와"),
+    DACHSHUND("닥스훈트"),
+    GOLDEN_RETRIEVER("골든리트리버"),
+    LABRADOR_RETRIEVER("래브라도리트리버"),
+    SIBERIAN_HUSKY("시베리안허스키"),
+    ALASKAN_MALAMUTE("알래스칸말라뮤트"),
+    SAMOYED("사모예드"),
+    MINIATURE_SCHNAUZER("미니어쳐슈나우저"),
+    BICHON("비숑"),
+    BOSTON_TERRIER("보스턴 테리어"),
+    BEAGLE("비글"),
+    SHETLAND_SHEEPDOG("셰틀랜드 쉽독"),
+    STANDARD_POODLE("스탠더드 푸들"),
+    SHIBA("시바"),
+    WELSH_CORGI("윌시 코기"),
+    JINDO("진돗개"),
+    GREYHOUND("그레이 하운드"),
+    AMERICAN_COCKER_SPANIEL("아메리칸 코카스파니엘"),
+    SPITZ("스피치"),
+    BULLDOG("불도그"),
+    MIX("믹스"),
+    ETC("기타");
+    companion object {
+        fun valueOfDogType(type: String?): DogType? {
+            return values().find { it.type == type }
+        }
+    }
+
 }

--- a/src/main/kotlin/com/example/mungmung/mungWiki/entity/MungWiki.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/entity/MungWiki.kt
@@ -29,12 +29,10 @@ class MungWiki() {
     @NotNull
     private var dogImgName : String? = null
 
-    @Column(nullable = false)
     @NotNull
     @OneToOne(fetch = FetchType.LAZY)
     private var wikiDocument : WikiDocument? = null
 
-    @Column(nullable = false)
     @NotNull
     @OneToOne(fetch = FetchType.LAZY)
     private var dogStatus : DogStatus? = null

--- a/src/main/kotlin/com/example/mungmung/mungWiki/entity/MungWiki.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/entity/MungWiki.kt
@@ -1,0 +1,42 @@
+package com.example.mungmung.mungWiki.entity
+
+import jakarta.persistence.*
+import lombok.NoArgsConstructor
+import lombok.Setter
+import org.jetbrains.annotations.NotNull
+
+@Entity
+@NoArgsConstructor
+@Setter
+class MungWiki() {
+    constructor(dogType: DogType?, dogImgName: String?, wikiDocument: WikiDocument?, dogStatus: DogStatus?) : this(){
+        this.dogType = dogType
+        this.dogImgName = dogImgName
+        this.wikiDocument = wikiDocument
+        this.dogStatus = dogStatus
+    }
+
+    @Id
+    @Column(name = "wiki_Id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private var id : Long? = null
+
+    @Column(nullable = false)
+    @NotNull
+    private var dogType : DogType? = null
+
+    @Column(nullable = false)
+    @NotNull
+    private var dogImgName : String? = null
+
+    @Column(nullable = false)
+    @NotNull
+    @OneToOne(fetch = FetchType.LAZY)
+    private var wikiDocument : WikiDocument? = null
+
+    @Column(nullable = false)
+    @NotNull
+    @OneToOne(fetch = FetchType.LAZY)
+    private var dogStatus : DogStatus? = null
+
+}

--- a/src/main/kotlin/com/example/mungmung/mungWiki/entity/WikiDocument.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/entity/WikiDocument.kt
@@ -1,0 +1,36 @@
+package com.example.mungmung.mungWiki.entity
+
+import jakarta.persistence.*
+import lombok.NoArgsConstructor
+import lombok.Setter
+import org.jetbrains.annotations.NotNull
+
+@Entity
+@NoArgsConstructor
+@Setter
+class WikiDocument() {
+
+    constructor(totalStatus: Long?, documentation: String?) : this(){
+        this.totalStatus = totalStatus
+        this.documentation = documentation
+    }
+
+    @Id
+    @Column(name = "wikiDocument_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private var id : Long? = null
+
+    @Column(nullable = false)
+    @NotNull
+    private var totalStatus : Long? = null
+
+    @Column(nullable = false)
+    @NotNull
+    private var documentation : String? =null
+
+
+    @PrePersist
+    private fun validate() {
+        require(totalStatus != null && 0<= totalStatus!! || totalStatus!! <= 5) { "totalStatus must be between 0 and 5" }
+    }
+}

--- a/src/main/kotlin/com/example/mungmung/mungWiki/repository/DogStatusRepository.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/repository/DogStatusRepository.kt
@@ -1,0 +1,11 @@
+package com.example.mungmung.mungWiki.repository
+
+import com.example.mungmung.mungWiki.entity.DogStatus
+import com.example.mungmung.mungWiki.entity.MungWiki
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface DogStatusRepository : JpaRepository<DogStatus, Long> {
+
+    override fun <S : DogStatus?> save(entity: S): S
+
+}

--- a/src/main/kotlin/com/example/mungmung/mungWiki/repository/MungWikiRepository.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/repository/MungWikiRepository.kt
@@ -1,9 +1,15 @@
 package com.example.mungmung.mungWiki.repository
 
+import com.example.mungmung.mungWiki.entity.DogType
 import com.example.mungmung.mungWiki.entity.MungWiki
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.util.*
 
 interface MungWikiRepository: JpaRepository<MungWiki, Long> {
 
     override fun <S : MungWiki?> save(entity: S): S
+
+    @Query("select m from MungWiki m where m.dogType = :dogType")
+    fun findByDogType(dogType: DogType?): Optional<MungWiki?>?
 }

--- a/src/main/kotlin/com/example/mungmung/mungWiki/repository/MungWikiRepository.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/repository/MungWikiRepository.kt
@@ -1,0 +1,9 @@
+package com.example.mungmung.mungWiki.repository
+
+import com.example.mungmung.mungWiki.entity.MungWiki
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MungWikiRepository: JpaRepository<MungWiki, Long> {
+
+    override fun <S : MungWiki?> save(entity: S): S
+}

--- a/src/main/kotlin/com/example/mungmung/mungWiki/repository/WikiDocumentRepository.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/repository/WikiDocumentRepository.kt
@@ -1,0 +1,10 @@
+package com.example.mungmung.mungWiki.repository
+
+import com.example.mungmung.mungWiki.entity.WikiDocument
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface WikiDocumentRepository: JpaRepository<WikiDocument,Long> {
+
+    override fun <S : WikiDocument?> save(entity: S): S
+
+}

--- a/src/main/kotlin/com/example/mungmung/mungWiki/request/RegisterRequest.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/request/RegisterRequest.kt
@@ -12,13 +12,9 @@ import lombok.ToString
 @ToString
 @RequiredArgsConstructor
 class RegisterRequest {
-    var dogType: DogType? = null
+    var dogType: String? = null
 
     var dogImgName: String? = null
-
-    var wikiDocument: WikiDocument? = null
-
-    var dogStatus: DogStatus? = null
 
     var intelligenceLevel : Long? = null
 
@@ -34,14 +30,6 @@ class RegisterRequest {
 
     var documentation : String? = null
 
-    fun toMungWiki(): MungWiki? {
-        return MungWiki(
-            this.dogType,
-            this.dogImgName,
-            this.wikiDocument,
-            this.dogStatus,
-        )
-    }
 
     fun toDogStatue() : DogStatus?{
         return DogStatus(

--- a/src/main/kotlin/com/example/mungmung/mungWiki/request/RegisterRequest.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/request/RegisterRequest.kt
@@ -1,0 +1,62 @@
+package com.example.mungmung.mungWiki.request
+
+import com.example.mungmung.mungWiki.entity.DogStatus
+import com.example.mungmung.mungWiki.entity.DogType
+import com.example.mungmung.mungWiki.entity.MungWiki
+import com.example.mungmung.mungWiki.entity.WikiDocument
+import lombok.Getter
+import lombok.RequiredArgsConstructor
+import lombok.ToString
+
+@Getter
+@ToString
+@RequiredArgsConstructor
+class RegisterRequest {
+    var dogType: DogType? = null
+
+    var dogImgName: String? = null
+
+    var wikiDocument: WikiDocument? = null
+
+    var dogStatus: DogStatus? = null
+
+    var intelligenceLevel : Long? = null
+
+    var sheddingLevel : Long? = null
+
+    var sociabilityLevel : Long? = null
+
+    var activityLevel : Long? = null
+
+    var indoorAdaptLevel : Long? = null
+
+    var totalStatus : Long? = null
+
+    var documentation : String? = null
+
+    fun toMungWiki(): MungWiki? {
+        return MungWiki(
+            this.dogType,
+            this.dogImgName,
+            this.wikiDocument,
+            this.dogStatus,
+        )
+    }
+
+    fun toDogStatue() : DogStatus?{
+        return DogStatus(
+            this.intelligenceLevel,
+            this.sheddingLevel,
+            this.sociabilityLevel,
+            this.activityLevel,
+            this.indoorAdaptLevel,
+        )
+    }
+
+    fun toWikiDocument() : WikiDocument?{
+        return WikiDocument(
+            this.totalStatus,
+            this.documentation
+        )
+    }
+}

--- a/src/main/kotlin/com/example/mungmung/mungWiki/service/MungWikiService.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/service/MungWikiService.kt
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service
 @Service
 interface MungWikiService {
 
-    fun registerWiki(request: RegisterRequest)
+    fun registerWiki(request: RegisterRequest) : String
 
 
 }

--- a/src/main/kotlin/com/example/mungmung/mungWiki/service/MungWikiService.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/service/MungWikiService.kt
@@ -1,0 +1,12 @@
+package com.example.mungmung.mungWiki.service
+
+import com.example.mungmung.mungWiki.request.RegisterRequest
+import org.springframework.stereotype.Service
+
+@Service
+interface MungWikiService {
+
+    fun registerWiki(request: RegisterRequest)
+
+
+}

--- a/src/main/kotlin/com/example/mungmung/mungWiki/service/MungWikiServiceImpl.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/service/MungWikiServiceImpl.kt
@@ -1,6 +1,6 @@
 package com.example.mungmung.mungWiki.service
 
-import com.example.mungmung.mungWiki.entity.DogStatus
+import com.example.mungmung.mungWiki.entity.DogType
 import com.example.mungmung.mungWiki.entity.MungWiki
 import com.example.mungmung.mungWiki.repository.DogStatusRepository
 import com.example.mungmung.mungWiki.repository.MungWikiRepository
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 
 @Service
-class MungWikiServiceImpl {
+class MungWikiServiceImpl:MungWikiService {
 
     @Autowired
     private lateinit var mungWikiRepository: MungWikiRepository
@@ -21,17 +21,22 @@ class MungWikiServiceImpl {
     @Autowired
     private lateinit var wikiDocumentRepository: WikiDocumentRepository
 
-    fun registerWiki(request: RegisterRequest) {
+    override fun registerWiki(request: RegisterRequest) : String{
+        return try {
+            val dogStatus = request.toDogStatue()
+            val wikiDocument = request.toWikiDocument()
 
-        val dogStatus = request.toDogStatue()
-        val wikiDocument = request.toWikiDocument()
+            dogStatusRepository.save(dogStatus)
+            wikiDocumentRepository.save(wikiDocument)
 
-        dogStatusRepository.save(dogStatus)
-        wikiDocumentRepository.save(wikiDocument)
+            var dogType : DogType? = DogType.valueOfDogType(request.dogType)
+            val mungWiki = MungWiki(dogType,request.dogImgName,wikiDocument ,dogStatus)
+            mungWikiRepository.save(mungWiki)
 
-
-        val mungWiki = MungWiki(request.dogType,request.dogImgName,wikiDocument ,dogStatus)
-        mungWikiRepository.save(mungWiki)
+            "새로운 위키 등록 성공!"
+        }catch (e :Exception){
+            e.toString()
+        }
     }
 
 }

--- a/src/main/kotlin/com/example/mungmung/mungWiki/service/MungWikiServiceImpl.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/service/MungWikiServiceImpl.kt
@@ -1,11 +1,37 @@
 package com.example.mungmung.mungWiki.service
 
-
+import com.example.mungmung.mungWiki.entity.DogStatus
+import com.example.mungmung.mungWiki.entity.MungWiki
+import com.example.mungmung.mungWiki.repository.DogStatusRepository
+import com.example.mungmung.mungWiki.repository.MungWikiRepository
+import com.example.mungmung.mungWiki.repository.WikiDocumentRepository
+import com.example.mungmung.mungWiki.request.RegisterRequest
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 
 @Service
 class MungWikiServiceImpl {
 
+    @Autowired
+    private lateinit var mungWikiRepository: MungWikiRepository
 
+    @Autowired
+    private lateinit var dogStatusRepository: DogStatusRepository
+
+    @Autowired
+    private lateinit var wikiDocumentRepository: WikiDocumentRepository
+
+    fun registerWiki(request: RegisterRequest) {
+
+        val dogStatus = request.toDogStatue()
+        val wikiDocument = request.toWikiDocument()
+
+        dogStatusRepository.save(dogStatus)
+        wikiDocumentRepository.save(wikiDocument)
+
+
+        val mungWiki = MungWiki(request.dogType,request.dogImgName,wikiDocument ,dogStatus)
+        mungWikiRepository.save(mungWiki)
+    }
 
 }

--- a/src/main/kotlin/com/example/mungmung/mungWiki/service/MungWikiServiceImpl.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/service/MungWikiServiceImpl.kt
@@ -8,6 +8,7 @@ import com.example.mungmung.mungWiki.repository.WikiDocumentRepository
 import com.example.mungmung.mungWiki.request.RegisterRequest
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import java.util.*
 
 @Service
 class MungWikiServiceImpl:MungWikiService {
@@ -23,17 +24,23 @@ class MungWikiServiceImpl:MungWikiService {
 
     override fun registerWiki(request: RegisterRequest) : String{
         return try {
-            val dogStatus = request.toDogStatue()
-            val wikiDocument = request.toWikiDocument()
-
-            dogStatusRepository.save(dogStatus)
-            wikiDocumentRepository.save(wikiDocument)
-
             var dogType : DogType? = DogType.valueOfDogType(request.dogType)
-            val mungWiki = MungWiki(dogType,request.dogImgName,wikiDocument ,dogStatus)
-            mungWikiRepository.save(mungWiki)
+            var maybeMungWiki : Optional<MungWiki?>? = mungWikiRepository.findByDogType(dogType)
 
-            "새로운 위키 등록 성공!"
+            if(maybeMungWiki!!.isPresent){
+                "이미 등록된 강아지 종입니다"
+            }else{
+
+                val dogStatus = request.toDogStatue()
+                val wikiDocument = request.toWikiDocument()
+                dogStatusRepository.save(dogStatus)
+                wikiDocumentRepository.save(wikiDocument)
+
+                val mungWiki = MungWiki(dogType,request.dogImgName,wikiDocument ,dogStatus)
+                mungWikiRepository.save(mungWiki)
+
+                "새로운 위키 등록 성공!"
+            }
         }catch (e :Exception){
             e.toString()
         }

--- a/src/main/kotlin/com/example/mungmung/mungWiki/service/MungWikiServiceImpl.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/service/MungWikiServiceImpl.kt
@@ -1,0 +1,11 @@
+package com.example.mungmung.mungWiki.service
+
+
+import org.springframework.stereotype.Service
+
+@Service
+class MungWikiServiceImpl {
+
+
+
+}


### PR DESCRIPTION
**feat :[최재민] mung Wiki도매인을 관리 하기 위한 엔티티 설계 시스템[mung-back7]**
- [x]  엔티티 별로 조건에 맞는 column 작성 및 생성자 작성
- [x]  `MungWiki`  에 각각의 객체를 1대1 매핑한다.
- [x]  register Request 클래스를 작성하여 가공할 데이터를 정리 한다.
- [x]  status 의 능력치는 `@PrePersist` 를 활용하여 유효성검사를 한다.
- [x]  enum dogType 클래스 설계

**feat :[최재민] mung Wiki 에 초기 데이터를 등록하기 위한 register 서비스[mung-back8]**
- [x]  생성자를 통해 request 에 객체 만들기
- [x]  service에서 저장소 불러와 DB에 저장
- [x]  기존에 해당 강아지 종이 저장되어있는지 확인 하는 유효성 검사 작성
- [x]  결과 별로 알맞은 결과값 리턴하기.