### PR TITLE
feat :[최재민] mung Wiki이미지 데이터를 관리 하기 위한 엔티티 생성 및 서비스 리팩토링[mung-back14]

### DIFF
--- a/src/main/kotlin/com/example/mungmung/mungWiki/controller/mungWikiController.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/controller/mungWikiController.kt
@@ -1,10 +1,13 @@
 package com.example.mungmung.mungWiki.controller
 
+import com.example.mungmung.mungWiki.entity.WikiImages
 import com.example.mungmung.mungWiki.request.RegisterRequest
 import com.example.mungmung.mungWiki.service.MungWikiService
 import lombok.extern.slf4j.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
 
 @Slf4j
 @RestController
@@ -15,10 +18,15 @@ class MungWikiController {
     @Autowired
     private lateinit var mungWikiService: MungWikiService
 
-    @PostMapping("/register")
-    open fun wikiRegister(@RequestBody registerRequest: RegisterRequest) : String{
+    @PostMapping(
+        value = ["/register"],
+        consumes = [MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE] )
+    open fun wikiRegister(
+        @RequestPart(value = "images") images: List<MultipartFile>,
+        @RequestPart(value = "info") request: RegisterRequest,
+        ) : String{
 
-
-        return mungWikiService.registerWiki(registerRequest)
+        return mungWikiService.registerWiki(request,images)
     }
+
 }

--- a/src/main/kotlin/com/example/mungmung/mungWiki/entity/MungWiki.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/entity/MungWiki.kt
@@ -5,13 +5,13 @@ import lombok.NoArgsConstructor
 import lombok.Setter
 import org.jetbrains.annotations.NotNull
 
+
 @Entity
 @NoArgsConstructor
 @Setter
 class MungWiki() {
-    constructor(dogType: DogType?, dogImgName: String?, wikiDocument: WikiDocument?, dogStatus: DogStatus?) : this(){
+    constructor(dogType: DogType?, wikiDocument: WikiDocument?, dogStatus: DogStatus?) : this(){
         this.dogType = dogType
-        this.dogImgName = dogImgName
         this.wikiDocument = wikiDocument
         this.dogStatus = dogStatus
     }
@@ -25,10 +25,6 @@ class MungWiki() {
     @NotNull
     private var dogType : DogType? = null
 
-    @Column(nullable = false)
-    @NotNull
-    private var dogImgName : String? = null
-
     @NotNull
     @OneToOne(fetch = FetchType.LAZY)
     private var wikiDocument : WikiDocument? = null
@@ -37,4 +33,11 @@ class MungWiki() {
     @OneToOne(fetch = FetchType.LAZY)
     private var dogStatus : DogStatus? = null
 
+    @NotNull
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "mungWiki")
+    private var wikiImages: List<WikiImages> = ArrayList()
+
+    fun setImages(wikiImages: List<WikiImages>){
+        this.wikiImages = wikiImages
+    }
 }

--- a/src/main/kotlin/com/example/mungmung/mungWiki/entity/WikiImages.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/entity/WikiImages.kt
@@ -1,0 +1,33 @@
+package com.example.mungmung.mungWiki.entity
+
+import jakarta.persistence.*
+import lombok.NoArgsConstructor
+import lombok.Setter
+
+@Entity
+@NoArgsConstructor
+@Setter
+class WikiImages(){
+
+    constructor(originalImageName : String?, uploadFileImageName :String?,mungWiki: MungWiki) : this() {
+        this.originalImageName = originalImageName
+        this.uploadFileImageName = uploadFileImageName
+        this.mungWiki = mungWiki
+
+    }
+
+    @Id
+    @Column(name = "wiki_Image_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private var id: Long? = null
+
+    @Column
+    private var originalImageName : String? = null
+
+    @Column
+    private var uploadFileImageName : String? = null
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "MungWiki_id")
+    private var mungWiki : MungWiki? = null
+}

--- a/src/main/kotlin/com/example/mungmung/mungWiki/repository/WikiImagesRepository.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/repository/WikiImagesRepository.kt
@@ -1,0 +1,10 @@
+package com.example.mungmung.mungWiki.repository
+
+import com.example.mungmung.mungWiki.entity.WikiImages
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface WikiImagesRepository : JpaRepository<WikiImages,Long> {
+
+    override fun <S : WikiImages?> save(entity: S): S
+
+}

--- a/src/main/kotlin/com/example/mungmung/mungWiki/request/RegisterRequest.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/request/RegisterRequest.kt
@@ -14,8 +14,6 @@ import lombok.ToString
 class RegisterRequest {
     var dogType: String? = null
 
-    var dogImgName: String? = null
-
     var intelligenceLevel : Long? = null
 
     var sheddingLevel : Long? = null
@@ -29,8 +27,6 @@ class RegisterRequest {
     var totalStatus : Long? = null
 
     var documentation : String? = null
-
-
     fun toDogStatue() : DogStatus?{
         return DogStatus(
             this.intelligenceLevel,

--- a/src/main/kotlin/com/example/mungmung/mungWiki/service/MungWikiService.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/service/MungWikiService.kt
@@ -2,11 +2,12 @@ package com.example.mungmung.mungWiki.service
 
 import com.example.mungmung.mungWiki.request.RegisterRequest
 import org.springframework.stereotype.Service
+import org.springframework.web.multipart.MultipartFile
 
 @Service
 interface MungWikiService {
 
-    fun registerWiki(request: RegisterRequest) : String
+    fun registerWiki(request: RegisterRequest , images : List<MultipartFile>) : String
 
 
 }

--- a/src/main/kotlin/com/example/mungmung/mungWiki/service/MungWikiServiceImpl.kt
+++ b/src/main/kotlin/com/example/mungmung/mungWiki/service/MungWikiServiceImpl.kt
@@ -2,13 +2,20 @@ package com.example.mungmung.mungWiki.service
 
 import com.example.mungmung.mungWiki.entity.DogType
 import com.example.mungmung.mungWiki.entity.MungWiki
+import com.example.mungmung.mungWiki.entity.WikiImages
 import com.example.mungmung.mungWiki.repository.DogStatusRepository
 import com.example.mungmung.mungWiki.repository.MungWikiRepository
 import com.example.mungmung.mungWiki.repository.WikiDocumentRepository
+import com.example.mungmung.mungWiki.repository.WikiImagesRepository
 import com.example.mungmung.mungWiki.request.RegisterRequest
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import org.springframework.web.multipart.MultipartFile
+import java.io.FileNotFoundException
+import java.io.FileOutputStream
+import java.io.IOException
 import java.util.*
+
 
 @Service
 class MungWikiServiceImpl:MungWikiService {
@@ -22,7 +29,10 @@ class MungWikiServiceImpl:MungWikiService {
     @Autowired
     private lateinit var wikiDocumentRepository: WikiDocumentRepository
 
-    override fun registerWiki(request: RegisterRequest) : String{
+    @Autowired
+    private lateinit var wikiImagesRepository : WikiImagesRepository
+
+    override fun registerWiki(request: RegisterRequest , images: List<MultipartFile>) : String{
         return try {
             var dogType : DogType? = DogType.valueOfDogType(request.dogType)
             var maybeMungWiki : Optional<MungWiki?>? = mungWikiRepository.findByDogType(dogType)
@@ -30,15 +40,43 @@ class MungWikiServiceImpl:MungWikiService {
             if(maybeMungWiki!!.isPresent){
                 "이미 등록된 강아지 종입니다"
             }else{
+                val wikiImages = mutableListOf<WikiImages>()
 
                 val dogStatus = request.toDogStatue()
                 val wikiDocument = request.toWikiDocument()
                 dogStatusRepository.save(dogStatus)
                 wikiDocumentRepository.save(wikiDocument)
-
-                val mungWiki = MungWiki(dogType,request.dogImgName,wikiDocument ,dogStatus)
+                val mungWiki = MungWiki(dogType,wikiDocument ,dogStatus)
                 mungWikiRepository.save(mungWiki)
 
+                for(image in images ) run {
+                    val uuid = UUID.randomUUID()
+                    var originalFileName: String? = image.originalFilename
+                    var uploadImageName : String = uuid.toString() + originalFileName
+                    var imageByte: ByteArray = image.bytes
+                    val image = WikiImages(originalFileName,uploadImageName,mungWiki)
+                    wikiImages.add(image)
+                    try{
+                        val writer = FileOutputStream(
+                            "../mung-front/src/assets/wikiDog/$uploadImageName"
+                        )
+                        writer.write(imageByte)
+                        writer.close()
+                        System.out.println("file upload success")
+                    }catch (e : FileNotFoundException){
+                        throw RuntimeException(e);
+                    }catch (e : IOException){
+                        throw RuntimeException(e);
+                    }
+                }
+
+                for (i in 0..wikiImages.size-1) {
+                    wikiImagesRepository.save(wikiImages[i])
+                }
+                var maybeMungWiki : Optional<MungWiki?>? = mungWikiRepository.findByDogType(dogType)
+                var newMungWiki : MungWiki = maybeMungWiki?.get()!!
+                newMungWiki.setImages(wikiImages)
+                mungWikiRepository.save(newMungWiki)
                 "새로운 위키 등록 성공!"
             }
         }catch (e :Exception){


### PR DESCRIPTION
- [x]  WIkiImages 엔티티와 repository 생성
- [x]  기존 MungWiki와 ManyToOne 관계 매핑
- [x]  기존 MungWiki 에 setImages 매서드 추가 작성
- [x]  프론트 디렉토리에 이미지 파일을 위치 시키는 서비스 추가 작성.